### PR TITLE
gem としてインストールすると LoadError が出る問題を修正

### DIFF
--- a/lib/lita/handlers/reviewer_lotto_cheating/handler.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/handler.rb
@@ -1,4 +1,4 @@
-require 'reviewer_lotto_cheating/github'
+require 'lita/handlers/reviewer_lotto_cheating/github'
 
 module Lita::Handlers::ReviewerLottoCheating
   class Handler < Lita::Handler
@@ -14,6 +14,6 @@ module Lita::Handlers::ReviewerLottoCheating
   end
 
   # load all handler classes
-  require 'reviewer_lotto_cheating/handlers/reviewer_handler'
-  require 'reviewer_lotto_cheating/handlers/user_handler'
+  require 'lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler'
+  require 'lita/handlers/reviewer_lotto_cheating/handlers/user_handler'
 end

--- a/lib/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler.rb
@@ -3,12 +3,12 @@
 require 'active_support/core_ext/integer/time'
 require 'uri'
 
-require 'reviewer_lotto_cheating/error'
-require 'reviewer_lotto_cheating/models/pullrequest'
-require 'reviewer_lotto_cheating/models/user'
-require 'reviewer_lotto_cheating/responder'
-require 'reviewer_lotto_cheating/selector'
-require 'reviewer_lotto_cheating/handler'
+require 'lita/handlers/reviewer_lotto_cheating/error'
+require 'lita/handlers/reviewer_lotto_cheating/models/pullrequest'
+require 'lita/handlers/reviewer_lotto_cheating/models/user'
+require 'lita/handlers/reviewer_lotto_cheating/responder'
+require 'lita/handlers/reviewer_lotto_cheating/selector'
+require 'lita/handlers/reviewer_lotto_cheating/handler'
 
 module Lita::Handlers::ReviewerLottoCheating
   class ReviewerHandler < Handler

--- a/lib/lita/handlers/reviewer_lotto_cheating/handlers/user_handler.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/handlers/user_handler.rb
@@ -3,8 +3,8 @@
 require 'active_support/core_ext/hash'
 require 'lita-keyword-arguments'
 
-require 'reviewer_lotto_cheating/handler'
-require 'reviewer_lotto_cheating/models/user'
+require 'lita/handlers/reviewer_lotto_cheating/handler'
+require 'lita/handlers/reviewer_lotto_cheating/models/user'
 
 module Lita::Handlers::ReviewerLottoCheating
   class UserHandler < Handler

--- a/lib/lita/handlers/reviewer_lotto_cheating/models/pullrequest.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/models/pullrequest.rb
@@ -3,8 +3,8 @@
 require 'active_support/core_ext/hash'
 require 'forwardable'
 
-require 'reviewer_lotto_cheating/error'
-require 'reviewer_lotto_cheating/model'
+require 'lita/handlers/reviewer_lotto_cheating/error'
+require 'lita/handlers/reviewer_lotto_cheating/model'
 
 module Lita::Handlers::ReviewerLottoCheating
   class Pullrequest < Model

--- a/lib/lita/handlers/reviewer_lotto_cheating/models/user.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/object/blank'
-require 'reviewer_lotto_cheating/model'
+require 'lita/handlers/reviewer_lotto_cheating/model'
 
 module Lita::Handlers::ReviewerLottoCheating
   class User < Model

--- a/lib/lita/handlers/reviewer_lotto_cheating/responder.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/responder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/descendants_tracker'
-require 'reviewer_lotto_cheating/common/translatable'
+require 'lita/handlers/reviewer_lotto_cheating/common/translatable'
 
 module Lita::Handlers::ReviewerLottoCheating
   class Responder
@@ -14,7 +14,7 @@ module Lita::Handlers::ReviewerLottoCheating
   end
 
   # load all responder classes
-  require 'reviewer_lotto_cheating/responders/chat_responder'
-  require 'reviewer_lotto_cheating/responders/github_comment_responder'
-  require 'reviewer_lotto_cheating/responders/github_status_check_responder'
+  require 'lita/handlers/reviewer_lotto_cheating/responders/chat_responder'
+  require 'lita/handlers/reviewer_lotto_cheating/responders/github_comment_responder'
+  require 'lita/handlers/reviewer_lotto_cheating/responders/github_status_check_responder'
 end

--- a/lib/lita/handlers/reviewer_lotto_cheating/responders/chat_responder.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/responders/chat_responder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'lita'
-require 'reviewer_lotto_cheating/responder'
+require 'lita/handlers/reviewer_lotto_cheating/responder'
 
 module Lita::Handlers::ReviewerLottoCheating
   class ChatResponder < Responder

--- a/lib/lita/handlers/reviewer_lotto_cheating/responders/github_comment_responder.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/responders/github_comment_responder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'reviewer_lotto_cheating/responder'
+require 'lita/handlers/reviewer_lotto_cheating/responder'
 
 module Lita::Handlers::ReviewerLottoCheating
   class GithubCommentResponder < Responder

--- a/lib/lita/handlers/reviewer_lotto_cheating/responders/github_status_check_responder.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/responders/github_status_check_responder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'reviewer_lotto_cheating/responder'
+require 'lita/handlers/reviewer_lotto_cheating/responder'
 
 module Lita::Handlers::ReviewerLottoCheating
   # display in status check

--- a/lib/lita/handlers/reviewer_lotto_cheating/selector.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/selector.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'reviewer_lotto_cheating/models/pullrequest'
-require 'reviewer_lotto_cheating/models/user'
-require 'reviewer_lotto_cheating/error'
+require 'lita/handlers/reviewer_lotto_cheating/models/pullrequest'
+require 'lita/handlers/reviewer_lotto_cheating/models/user'
+require 'lita/handlers/reviewer_lotto_cheating/error'
 
 module Lita::Handlers::ReviewerLottoCheating
   class Selector

--- a/lita-reviewer-lotto-cheating.gemspec
+++ b/lita-reviewer-lotto-cheating.gemspec
@@ -1,6 +1,3 @@
-lib = File.expand_path('../lib/lita/handlers', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
 Gem::Specification.new do |spec|
   spec.name          = 'lita-reviewer-lotto-cheating'
   spec.version       = '0.1.0'


### PR DESCRIPTION
## やりたいこと

このライブラリを bundler などで gem としてインストールして、 lita を起動すると、以下のように `LoadError` になってしまう。この問題を解決したい。

```shell
$ bundle exec dotenv lita start
path/to/lita-reviewer-lotto-cheating-2ad979a50040/lib/lita/handlers/reviewer_lotto_cheating/handler.rb:1:in `require': cannot load such file -- reviewer_lotto_cheating/github (LoadError)
```

## やったこと

- ライブラリ内のモジュールをロードする際に独自の `LOAD_PATH` を追加して、そこからのパスを require していたのを、 `LOAD_PATH` の追加をやめ、`lib/` からのパスを指定するようにした。

## レビュー時、リリース後の動作確認方法

新しく lita のプロジェクトを作り、 `Gemfile` に以下を追加して、インストールした後、

```
gem 'lita-reviewer-lotto-cheating', github: 'ClinicalPlatform/lita-reviewer-lotto-cheating'
```

lita を起動してエラーが出ない事を確認してください。

```shell
$ bundle exec dotenv lita start
```