### PR TITLE
Lotto should choose at least 2 people even when either of level are empty

### DIFF
--- a/lib/lita/handlers/reviewer_lotto_cheating/selector.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/selector.rb
@@ -21,30 +21,37 @@ module Lita::Handlers::ReviewerLottoCheating
 
       def select(users, reviewed_counts)
         siniors, juniors = users.partition { |user| user.level > 1 }
+        hasEmptyGroup = [siniors, juniors].any?(&:empty?)
 
-        [siniors, juniors].map do |group|
-          user_points = group.map do |u|
-            num_working_days = u.working_days.size.nonzero? || 1
-            # reviewed point is multiplied by 100 and rounded off
-            point = (reviewed_counts.fetch(u.name, 0).to_f / num_working_days * 100).round
-            [u, point]
-          end.to_h
-
-          max_point = user_points.max_by {|t| t[1] }&.at(1)&.nonzero? || 100
-          sorted = group.sort_by do |u|
-            # final point consists of the ratio of 'reviewed point' to 'random point' are 8 : 2
-            reviewed_point = user_points.fetch(u, 0) * 8
-            random_point   = (rand(max_point) + 1) * 2
-            point          = reviewed_point + random_point
-            Lita.logger.debug(
-              "[#{u.name} - lv.#{u.level}] review: #{reviewed_point}, " \
-              "random: #{random_point}: total: #{point}"
-            )
-            point
+        [siniors, juniors]
+          .map do |group|
+            sorted = sort_users_by_point_and_lotto(group, reviewed_counts)
+            sorted.take(hasEmptyGroup ? 2 : 1)
           end
-          sorted.first
+          .flatten
+          .compact
+      end
+
+      def sort_users_by_point_and_lotto(users, reviewed_counts)
+        user_points = users.map do |u|
+          num_working_days = u.working_days.size.nonzero? || 1
+          # reviewed point is multiplied by 100 and rounded off
+          point = (reviewed_counts.fetch(u.name, 0).to_f / num_working_days * 100).round
+          [u, point]
+        end.to_h
+
+        max_point = user_points.max_by { |t| t[1] }&.at(1)&.nonzero? || 100
+        users.sort_by do |u|
+          # final point consists of the ratio of 'reviewed point' to 'random point' are 8 : 2
+          reviewed_point = user_points.fetch(u, 0) * 8
+          random_point   = (rand(max_point) + 1) * 2
+          point          = reviewed_point + random_point
+          Lita.logger.debug(
+            "[#{u.name} - lv.#{u.level}] review: #{reviewed_point}, " \
+            "random: #{random_point}: total: #{point}"
+          )
+          point
         end
-        .compact
       end
     end
   end

--- a/spec/lita/handlers/reviewer_lotto_cheating/selector_spec.rb
+++ b/spec/lita/handlers/reviewer_lotto_cheating/selector_spec.rb
@@ -80,11 +80,11 @@ describe Lita::Handlers::ReviewerLottoCheating::Selector, model: true do
     context 'with no senior reviewer' do
       let (:users) { [ junior1, junior2 ] }
       let(:user_points) do
-        { 'junior1' => 2, 'junior2' => 3 }
+        { 'junior1' => 2, 'junior2' => 3, 'junior3' => 4 }
       end
 
-      it 'return only 1 reviewer' do
-        expect(subject).to eq [junior1]
+      it 'return 2 reviewers from juniors' do
+        expect(subject).to eq [junior1, junior2]
       end
     end
 


### PR DESCRIPTION
```shell
# $ bundle exec dotenv lita start
lita > lita reviewer list
...
- senior4  level: 2  working_days: ["Mon", "Tue", "Wed", "Thu", "Fri"]
- senior3  level: 2  working_days: ["Thu", "Fri"]
- senior1  level: 2  working_days: ["Mon", "Tue"]
- senior2  level: 2  working_days: ["Mon", "Tue", "Wed", "Thu", "Fri"]

lita > lita reviewer https://github.com/hyone/test1/pull/7
...
@senior4, @senior2 are assigned as the reviewers for https://github.com/hyone/test1/pull/7!!
```