### PR TITLE
Exceptions occur when no reviewers are registered

### DIFF
--- a/lib/lita/handlers/reviewer_lotto_cheating/handlers/user_handler.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/handlers/user_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/object/blank'
 require 'lita-keyword-arguments'
 
 require 'lita/handlers/reviewer_lotto_cheating/handler'
@@ -44,7 +45,7 @@ module Lita::Handlers::ReviewerLottoCheating
                 u.working_days.map { |wday| t('date.abbr_day_names')[wday] })
       end.join("\n")
 
-      response.reply(text)
+      response.reply(text.presence || t('error.no_user_registered'))
     end
 
     def add_user(response)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -15,6 +15,7 @@ en:
           comment_failure: "Failed to write comment: %{text}"
           user_not_found: "User not found: %{name}"
           user_already_exists: "User already exists: %{name}"
+          no_user_registered: "no user registered."
         message:
           upserted: "%{name} is successfully added (updated)."
           already_assigned: "%{url} has already been assigned reviewers."


### PR DESCRIPTION
When I type `bot reviewer list` when reviewers are not assigned, it fails. I pasted the log below.

```
[2017-01-17 04:45:34 UTC] ERROR: Lita::Handlers::ReviewerLottoCheating::UserHandler crashed. The exception was:
Slack API call to chat.postMessage returned an error: no_text.
Full backtrace:
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/api.rb:99:in `call_api'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/api.rb:59:in `send_messages'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack.rb:43:in `send_messages'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/robot.rb:129:in `send_messages'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-pebbles-0.2.1/lib/lita/ext/message.rb:12:in `reply_without_mention'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-pebbles-0.2.1/lib/lita/ext/message.rb:7:in `reply'
/var/bot/shared/bundle/ruby/2.3.0/bundler/gems/lita-reviewer-lotto-cheating-baa4bc1efbab/lib/lita/handlers/reviewer_lotto_cheating/handlers/user_handler.rb:47:in `list_user'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/callback.rb:31:in `public_send'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/callback.rb:31:in `call'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/handler/chat_router.rb:97:in `dispatch_to_route'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/handler/chat_router.rb:82:in `block in dispatch'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/handler/chat_router.rb:72:in `map'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/handler/chat_router.rb:72:in `dispatch'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/robot.rb:69:in `block in receive'
/usr/local/rbenv/versions/2.3.3/lib/ruby/2.3.0/set.rb:306:in `each_key'
/usr/local/rbenv/versions/2.3.3/lib/ruby/2.3.0/set.rb:306:in `each'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/robot.rb:66:in `map'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-4.7.1/lib/lita/robot.rb:66:in `receive'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/message_handler.rb:122:in `dispatch_message'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/message_handler.rb:159:in `handle_message'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/message_handler.rb:18:in `handle'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/rtm_connection.rb:100:in `block in receive_message'
/var/bot/shared/bundle/ruby/2.3.0/gems/lita-slack-1.8.0/lib/lita/adapters/slack/event_loop.rb:10:in `block in defer'
/var/bot/shared/bundle/ruby/2.3.0/gems/eventmachine-1.2.1/lib/eventmachine.rb:1076:in `block in spawn_threadpool'
```