### PR TITLE
Add -f option to overwrite reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ $ bundle exec lita
 Choice 2 reviewers for `GITHUB_PR_URL`.
 And then notice them to us on chat, `GITHUB_PR_URL` comment and status checker
 
+Options:
+
+- `-f` , `--force`
+
+  force to assign reviewers even though GITHUB_PR_URL has been alraedy assigned them to.
+
 #### lita reviewer list
 
     lita reviewer list

--- a/lib/lita/handlers/reviewer_lotto_cheating/models/pullrequest.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/models/pullrequest.rb
@@ -37,6 +37,12 @@ module Lita::Handlers::ReviewerLottoCheating
       @redis.sadd(key, reviewers.map(&:name))
     end
 
+    def delete
+      @redis.srem(PULLREQUESTS_KEY, @pr.id)
+      @redis.zrem(ORDERED_PULLREQUESTS_KEY, key)
+      @redis.del(key)
+    end
+
     def latest_commit
       @pr.head.sha
     end

--- a/spec/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler_spec.rb
+++ b/spec/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler_spec.rb
@@ -108,7 +108,19 @@ describe Lita::Handlers::ReviewerLottoCheating::ReviewerHandler, lita_handler: t
         end
         it { is_expected.to eq 'https://github.com/foobar/test1/pull/3 has already been assigned reviewers.' }
       end
+
+      context 'and send reviewer command again with -f option' do
+        before do
+          VCR.use_cassette('foobar/test1/pull/3') do
+            send_command('reviewer https://github.com/foobar/test1/pull/3 -f')
+          end
+        end
+
+        it do
+          is_expected.to eq \
+            '@test2, @test1 are assigned as the reviewers for https://github.com/foobar/test1/pull/3!!'
+        end
+      end
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,12 @@ RSpec.configure do |config|
     keys = Lita.redis.keys("*")
     Lita.redis.del(keys) unless keys.empty?
   end
+
+  # Register lita extensions.
+  # see: https://docs.lita.io/plugin-authoring/extensions/#using-extensions
+  config.before(:each, lita_handler: true) do
+    registry.register_hook(:trigger_route, Lita::Extensions::KeywordArguments)
+  end
 end
 
 class UserMock < Struct.new(:name, :level, :working_days); end


### PR DESCRIPTION
`lita review URL` doesn't  re-assign reviewers so far.  I hope to have `lita review -f URL` to update reviewers.