### PR TITLE
Support to configure the randomness weight in the reviewers selection factors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ generate access token on github form [here](https://github.com/settings/tokens/n
    duration time (second) from now, during which we calculate review count
    of each user for selecting reviewers
 
+* `random_weight` (Fixnum in 0..100)
+
+   percentage number of the randomness factor in the reviwers selection factors
+
 * `chat_target` (Object)
 
    chat tareget that this plugin responses

--- a/lib/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler.rb
@@ -27,6 +27,14 @@ module Lita::Handlers::ReviewerLottoCheating
            type: [Fixnum, ActiveSupport::Duration],
            default: 30 * 24 * 60 * 60
 
+    # percentage number of the randomness factor in the reviwers selection factors
+    #
+    # it can be specified as `Fixnum` literal (0-100)
+    config :random_weight, type: Fixnum, default: 20
+    config :random_weight do
+      validate { |v| !(0..100).include?(v) }
+    end
+
     # room (channel) or user to which this handler sends messages
     config :chat_target, type: Hash, default: { room: '#general' }
 
@@ -111,7 +119,8 @@ module Lita::Handlers::ReviewerLottoCheating
       reviewers =
         begin
           Selector.call(users: User.reviewer_candidates(pr.user.login),
-                        duration: config.reviewer_count_duration)
+                        duration: config.reviewer_count_duration,
+                        random_weight: config.random_weight)
         rescue Error => e
           return on_error(e.message)
         end

--- a/lib/lita/handlers/reviewer_lotto_cheating/selector.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/selector.rb
@@ -7,31 +7,31 @@ require 'lita/handlers/reviewer_lotto_cheating/error'
 module Lita::Handlers::ReviewerLottoCheating
   class Selector
     class << self
-      def call(users:, duration:)
+      def call(users:, duration:, random_weight: nil)
         raise Error.new('no user as reviewer candidation') if users.empty?
 
         user_points = Pullrequest.calc_review_counts(duration: duration)
         Lita.logger.debug("Current reviewer counts: #{user_points}")
 
-        select(users, user_points)
+        select(users, user_points, random_weight: random_weight)
       end
 
       private
 
-      def select(users, reviewed_counts)
+      def select(users, reviewed_counts, random_weight: nil)
         siniors, juniors = users.partition { |user| user.level > 1 }
         hasEmptyGroup = [siniors, juniors].any?(&:empty?)
 
         [siniors, juniors]
           .map do |group|
-            sorted = sort_users_by_point_and_lotto(group, reviewed_counts)
+            sorted = sort_users_by_point_and_lotto(group, reviewed_counts, random_weight: random_weight)
             sorted.take(hasEmptyGroup ? 2 : 1)
           end
           .flatten
           .compact
       end
 
-      def sort_users_by_point_and_lotto(users, reviewed_counts)
+      def sort_users_by_point_and_lotto(users, reviewed_counts, random_weight: nil)
         user_points = users.map do |u|
           num_working_days = u.working_days.size.nonzero? || 1
           # reviewed point is multiplied by 100 and rounded off
@@ -39,14 +39,18 @@ module Lita::Handlers::ReviewerLottoCheating
           [u, point]
         end.to_h
 
+        random_weight = random_weight.try! { self % 101 } || 20    # default 20
+        review_weight = 100 - random_weight
+        Lita.logger.debug("Sort reviewrs (reviewed : random is #{review_weight} : #{random_weight})")
+
         max_point = user_points.max_by { |t| t[1] }&.at(1)&.nonzero? || 100
+
         users.sort_by do |u|
-          # final point consists of the ratio of 'reviewed point' to 'random point' are 8 : 2
-          reviewed_point = user_points.fetch(u, 0) * 8
-          random_point   = (rand(max_point) + 1) * 2
-          point          = reviewed_point + random_point
+          review_point = user_points.fetch(u, 0) * review_weight
+          random_point = (rand(max_point) + 1)   * random_weight
+          point        = review_point + random_point
           Lita.logger.debug(
-            "[#{u.name} - lv.#{u.level}] review: #{reviewed_point}, " \
+            "[#{u.name} - lv.#{u.level}] review: #{review_point}, " \
             "random: #{random_point}: total: #{point}"
           )
           point

--- a/spec/lita/handlers/reviewer_lotto_cheating/selector_spec.rb
+++ b/spec/lita/handlers/reviewer_lotto_cheating/selector_spec.rb
@@ -31,8 +31,9 @@ describe Lita::Handlers::ReviewerLottoCheating::Selector, model: true do
     let (:junior1) { UserMock.new('junior1', 1, [1, 2, 3, 4, 5]) }
     let (:junior2) { UserMock.new('junior2', 1, [1, 2, 3, 4, 5]) }
     let (:users) { [ senior1, senior2, junior1, junior2 ] }
+    let (:random_weight) { nil }
 
-    subject { described_class.send(:select, users, user_points) }
+    subject { described_class.send(:select, users, user_points, random_weight: random_weight) }
 
     # ignore randomness
     before do
@@ -75,6 +76,53 @@ describe Lita::Handlers::ReviewerLottoCheating::Selector, model: true do
       let(:user_points) { {} }
 
       it { is_expected.to eq [] }
+    end
+
+    context 'when specifying random_weight' do
+      let(:user_points) do
+        { 'senior1' => 2, 'senior2' => 5, 'junior1' => 3, 'junior2' => 2 }
+      end
+      before do
+        allow(described_class).to receive(:rand).and_return(100, 40, 40, 90)
+      end
+
+      context 'with random_weight 0' do
+        let(:random_weight) { 0 }
+        it 'return senior1, junior2' do
+          expect(subject).to eq [senior1, junior2]
+        end
+      end
+
+      # case senior1 point < senior2 point
+      context 'with random_weight 49' do
+        let(:random_weight) { 49 }
+        it 'return senior1, junior2' do
+          expect(subject).to eq [senior1, junior1]
+        end
+      end
+
+      # case senior1 point == senior2 point
+      context 'with random_weight 50' do
+        let(:random_weight) { 50 }
+        it 'return senior1, junior1' do
+          expect(subject).to eq [senior1, junior1]
+        end
+      end
+
+      # case senior1 point > senior2 point
+      context 'with random_weight 51' do
+        let(:random_weight) { 51 }
+        it 'return senior2, junior1' do
+          expect(subject).to eq [senior2, junior1]
+        end
+      end
+
+      context 'with random_weight 100' do
+        let(:random_weight) { 100 }
+        it 'return senior2, junior1' do
+          expect(subject).to eq [senior2, junior1]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR enables to configure the randomness weight in the reviewers selection factors.

`lita_config.rb` : 
```ruby
# must be in 0..100
config.handlers.reviewer_lotto_cheating.random_weight = 50
```