### PR TITLE
Suppress Fixnum deprecated warnings on ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ generate access token on github form [here](https://github.com/settings/tokens/n
 
 ### Optional attributes
 
-* `reviewer_count_duration` (Fixnum or ActiveSupport::Duration)
+* `reviewer_count_duration` (Integer or ActiveSupport::Duration)
 
    duration time (second) from now, during which we calculate review count
    of each user for selecting reviewers
 
-* `random_weight` (Fixnum in 0..100)
+* `random_weight` (Integer in 0..100)
 
    percentage number of the randomness factor in the reviwers selection factors
 

--- a/lib/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler.rb
+++ b/lib/lita/handlers/reviewer_lotto_cheating/handlers/reviewer_handler.rb
@@ -22,15 +22,15 @@ module Lita::Handlers::ReviewerLottoCheating
     # duration time (second) from now, during which we calculate review count
     # of each user for selecting reviewers
     #
-    # it can be specified `Fixnum` literal or `ActiveSupport::Duration` syntax
+    # it can be specified `Integer` literal or `ActiveSupport::Duration` syntax
     config :reviewer_count_duration,
-           type: [Fixnum, ActiveSupport::Duration],
+           type: [Integer, ActiveSupport::Duration],
            default: 30 * 24 * 60 * 60
 
     # percentage number of the randomness factor in the reviwers selection factors
     #
-    # it can be specified as `Fixnum` literal (0-100)
-    config :random_weight, type: Fixnum, default: 20
+    # it can be specified as `Integer` literal (0-100)
+    config :random_weight, type: Integer, default: 20
     config :random_weight do
       validate { |v| !(0..100).include?(v) }
     end


### PR DESCRIPTION
Rename `Fixnum` constant to `Integer` to suppress warnings on ruby 2.4 like below:

```
warning: constant ::Fixnum is deprecated
```